### PR TITLE
Fix secrets scan build failure by omitting known env vars

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,10 @@
   command = "npm run build:client"
   functions = "netlify/functions"
   publish = "dist/spa"
-  environment = { SECRETS_SCAN_OMIT_KEYS = "VITE_SUPABASE_URL,VITE_SUPABASE_ANON_KEY,PAYPAL_MODE" }
+
+[build.environment]
+  SECRETS_SCAN_OMIT_KEYS = "VITE_SUPABASE_URL,VITE_SUPABASE_ANON_KEY,PAYPAL_MODE"
+  SECRETS_SCAN_OMIT_PATHS = "supabase,dist/spa/assets/*"
 
 [functions]
   external_node_modules = ["express"]

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,12 +2,12 @@
   command = "npm run build:client"
   functions = "netlify/functions"
   publish = "dist/spa"
-
+  environment = { SECRETS_SCAN_OMIT_KEYS = "VITE_SUPABASE_URL,VITE_SUPABASE_ANON_KEY,PAYPAL_MODE" }
 
 [functions]
   external_node_modules = ["express"]
   node_bundler = "esbuild"
-  
+
 [[redirects]]
   force = true
   from = "/api/*"


### PR DESCRIPTION
## Purpose
Fix build failures caused by Netlify's secrets scanner detecting environment variable values in build output and repository files. The scanner was flagging `PAYPAL_MODE`, `VITE_SUPABASE_ANON_KEY`, and `VITE_SUPABASE_URL` as exposed secrets, preventing successful deployments.

## Code changes
- Added `[build.environment]` section to `netlify.toml`
- Configured `SECRETS_SCAN_OMIT_KEYS` to exclude the flagged environment variables: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, and `PAYPAL_MODE`
- Configured `SECRETS_SCAN_OMIT_PATHS` to exclude scanning in `supabase` directory and `dist/spa/assets/*` files where these values are expected to appear
- Minor formatting cleanup (removed trailing whitespace)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/58b62e47a1fc4552b099c90b02e8ac19/spark-studio)

👀 [Preview Link](https://58b62e47a1fc4552b099c90b02e8ac19-spark-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>58b62e47a1fc4552b099c90b02e8ac19</projectId>-->
<!--<branchName>spark-studio</branchName>-->